### PR TITLE
Periodic mode

### DIFF
--- a/src/vtgpio.c
+++ b/src/vtgpio.c
@@ -540,8 +540,6 @@ static struct kobject *vt_kobj;
  */
 static irq_handler_t vtgpio_irq_handler(unsigned int irq, void *dev_id,
                                         struct pt_regs *regs) {
-  trace_printk(KERN_INFO "rise\n");
-
   // Record how long until the timer expires, then cancel it.
   if (timer_pending(&vt_timer) && time_is_after_jiffies(vt_timer.expires)) {
     leftover = vt_timer.expires - jiffies;
@@ -558,8 +556,6 @@ static irq_handler_t vtgpio_irq_handler(unsigned int irq, void *dev_id,
  */
 static irq_handler_t vtgpio_irq_handler_fall(unsigned int irq, void *dev_id,
                                              struct pt_regs *regs) {
-  trace_printk(KERN_INFO "fall\n");
-
   resume();
   if (period > 0) {
     if (leftover > 0) { // Resumed from interrupt event.

--- a/src/vtgpio.h
+++ b/src/vtgpio.h
@@ -17,7 +17,7 @@
 #endif
 
 #define FTRACE 0 // Value to toggle ftrace vs regular prints.
-#define QUIET 1 // value to surpress real-time pause/resume.
+#define QUIET 0 // value to surpress real-time pause/resume.
 
 // Functions for pausing resuming processes and clocks.
 void pause(void);


### PR DESCRIPTION
Summary
======

1. Init module with synchronization period in milliseconds.

2. Schedule a pause once resumed, from either interrupt or
synchronization event:
   * In the *interrupt* case, timeout is what is leftover from a
   previously canceled timer.
   * In the *synchronization* case timeout is the period.

3. Add an sysfs entry `syncpause` to indicate whether current state is
paused and it is for the synchronization event. Userspace program can
poll this value, and then issue resume command.

Expected usage
============
In a set of embedded devices, only one of them load the module with `insmod vtgpio period=10` so that high/low voltage signals will be send to all devices 10 ms periodically.

Testplan
======
Pass compiler, need further experiment on embedded devices